### PR TITLE
Fix project structure path in word2ebook README

### DIFF
--- a/tool/word2ebook/README.md
+++ b/tool/word2ebook/README.md
@@ -14,7 +14,7 @@
 ## 项目结构
 
 ```
-word2ebook_/
+word2ebook/
 ├── core/                   # 核心解析模块
 │   ├── document_parser.py  # Word 文档解析器
 │   └── content_processor.py # 内容处理器


### PR DESCRIPTION
## Summary
- Correct incorrect path name in word2ebook README project structure

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a063ec8bb0832cb5320d29187478cf