### PR TITLE
Fix question block merging

### DIFF
--- a/tool/word2ebook/core/document_parser.py
+++ b/tool/word2ebook/core/document_parser.py
@@ -321,22 +321,25 @@ class DocumentParser:
             # 检查是否为问题开始
             if current_block.startswith('<div class="question">'):
                 # 收集所有连续的问题内容
+                current_block = current_block.rstrip()
+                if current_block.endswith('</div>'):
+                    current_block = current_block[:current_block.rfind('</div>')].rstrip()
                 question_parts = [current_block]
                 i += 1
-                
+
                 # 收集后续的普通段落作为问题内容的延续
                 while i < len(content_blocks):
                     next_block = content_blocks[i]
-                    
+
                     # 如果遇到新的问题、回答或标题，停止收集
-                    if (next_block.startswith('<div class="question">') or 
+                    if (next_block.startswith('<div class="question">') or
                         next_block.startswith('<div class="answer">') or
-                        next_block.startswith('<h1') or 
-                        next_block.startswith('<h2>') or 
+                        next_block.startswith('<h1') or
+                        next_block.startswith('<h2>') or
                         next_block.startswith('<h3>') or
                         next_block.startswith('<hr>')):
                         break
-                    
+
                     # 如果是普通段落，添加为问题内容
                     if next_block.startswith('<p>'):
                         content = next_block.replace('<p>', '').replace('</p>', '')
@@ -344,11 +347,10 @@ class DocumentParser:
                         i += 1
                     else:
                         break
-                
-                # 确保问题区块正确结束
-                if not question_parts[-1].endswith('</div>'):
-                    question_parts.append('</div>')
-                    
+
+                # 添加关闭标签，确保所有问题内容在同一个区块内
+                question_parts.append('</div>')
+
                 merged_blocks.append('\n'.join(question_parts))
                 
             # 检查是否为回答开始


### PR DESCRIPTION
## Summary
- Fix `_merge_qa_blocks` so extra question paragraphs are merged inside the original question `<div>`

## Testing
- `pytest -q`
- `python - <<'PY'
import sys
sys.path.append('tool/word2ebook')
from core.document_parser import DocumentParser
class Dummy:
    def __init__(self, **kwargs):
        self.__dict__.update(kwargs)
settings = Dummy(merge_qa_blocks=True, enable_back_to_top=False)
file_manager = Dummy()
parser = DocumentParser(settings, file_manager)
content_blocks = [
    '<div class="question">\n    <div class="question-meta">\n        <span class="questioner">A</span>\n    </div>\n    <div class="question-text">line1</div>\n</div>',
    '<p>line2</p>',
    '<p>line3</p>',
]
merged = parser._merge_qa_blocks(content_blocks)
print(merged[0])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a064459cac832cb23552e9d9879b35